### PR TITLE
Updating role to work in a disconnected cluster

### DIFF
--- a/roles/etcd-backup/defaults/main.yml
+++ b/roles/etcd-backup/defaults/main.yml
@@ -7,6 +7,7 @@ etcd_backup_user: "system:serviceaccount:{{ etcd_backup_namespace }}:{{ etcd_bac
 etcd_cluster_id: "demo"
 etcd_backup_pvc_claim: "{{ etcd_cluster_id }}-etcd-backup"
 etcd_backup_volume_size: "10Gi"
+etcd_backup_configmap: "etcd-backup-scripts"
 
 # Just documeting the variable. We set the variable using the set_fact module
 # etcd_image: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3c5301e86aa93d36d936cd5bd6b3575c98c4d33205be38c6dcbe09774b95ca7a"

--- a/roles/etcd-backup/files/etcd-backup.sh
+++ b/roles/etcd-backup/files/etcd-backup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+DATE=$(date +%Y%m%dT%H%M%S)
+
+# Attempting to call the regular backup script as our first attempt
+/usr/local/bin/etcd-snapshot-backup.sh /assets/backup/etcd-snapshot.db
+
+if [ $? -eq 0 ]; then
+    echo "Successfully downloaded etcdctl and backed up etcd database !!!"
+else
+    echo "Failed to backup etcd. Most likely a disconnected environment !!!"
+    echo "Calling the disconnected etcd backup script"
+    /usr/local/bin/etcd-snapshot-backup-disconnected.sh /assets/backup/etcd-snapshot.db
+fi
+if [ $? -eq 0 ]; then
+    mkdir /etcd-backup/${DATE}
+    cp -r /assets/backup/*  /etcd-backup/${DATE}/
+    echo 'Copied backup files to PVC mount point.'
+    exit 0
+fi
+echo "Backup attempts failed. Please FIX !!!"
+exit 1

--- a/roles/etcd-backup/files/etcd-snapshot-backup-disconnected.sh
+++ b/roles/etcd-backup/files/etcd-snapshot-backup-disconnected.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+# example
+# etcd-snapshot-backup.sh $path-to-snapshot
+
+if [[ $EUID -ne 0 ]]; then
+  echo "This script must be run as root"
+  exit 1
+fi
+
+usage () {
+    echo 'Path to backup file required: ./etcd-snapshot-backup.sh ./backup.db'
+    exit 1
+}
+
+ASSET_DIR=./assets
+
+if [ "$1" != "" ]; then
+  SNAPSHOT_FILE="$1"
+else
+  usage
+fi
+
+CONFIG_FILE_DIR=/etc/kubernetes
+MANIFEST_DIR="${CONFIG_FILE_DIR}/manifests"
+MANIFEST_STOPPED_DIR="${ASSET_DIR}/manifests-stopped"
+ETCDCTL="/usr/bin/etcdctl"
+ETCD_DATA_DIR=/var/lib/etcd
+ETCD_MANIFEST="${MANIFEST_DIR}/etcd-member.yaml"
+ETCD_STATIC_RESOURCES="${CONFIG_FILE_DIR}/static-pod-resources/etcd-member"
+STOPPED_STATIC_PODS="${ASSET_DIR}/tmp/stopped-static-pods"
+
+source "/usr/local/bin/openshift-recovery-tools"
+
+function run {
+  init
+  backup_etcd_client_certs
+  backup_manifest
+  snapshot_data_dir
+}
+
+run

--- a/roles/etcd-backup/tasks/configmap.yml
+++ b/roles/etcd-backup/tasks/configmap.yml
@@ -1,0 +1,4 @@
+- name: Create config map for custom backup scripts
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'configmap.yaml.j2') }}"

--- a/roles/etcd-backup/tasks/main.yml
+++ b/roles/etcd-backup/tasks/main.yml
@@ -12,6 +12,8 @@
 
 - include_tasks: get_etcd_image.yml
 
+- include_tasks: configmap.yml
+
 - name: Create CronJob
   k8s:
     state: present

--- a/roles/etcd-backup/templates/configmap.yaml.j2
+++ b/roles/etcd-backup/templates/configmap.yaml.j2
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ etcd_backup_configmap }}"
+  namespace: "{{ etcd_backup_namespace }}"
+data:
+  etcd-backup.sh: {{ lookup('file', 'etcd-backup.sh') | to_json }}
+  etcd-snapshot-backup-disconnected.sh: {{ lookup('file', 'etcd-snapshot-backup-disconnected.sh') | to_json }}
+  

--- a/roles/etcd-backup/templates/cronjob.yaml.j2
+++ b/roles/etcd-backup/templates/cronjob.yaml.j2
@@ -16,9 +16,7 @@ spec:
           activeDeadlineSeconds: 200
           containers:
           - command:
-            - /bin/sh
-            - -c
-            - LOGDATE=$(date +%Y%m%dT%H%M%S) ; /usr/local/bin/etcd-snapshot-backup.sh /etcd-backup/${LOGDATE}-snapshot.db
+            - /usr/local/bin/etcd-backup.sh
             image: {{ etcd_image }}
             imagePullPolicy: IfNotPresent
             name: etcd-backup
@@ -41,6 +39,12 @@ spec:
               name: scripts
             - mountPath: /etcd-backup
               name: etcd-backup
+            - mountPath: /usr/loca/bin/etcd-backup.sh
+              name: etcd-backup-scripts
+              subPath: etcd-backup.sh
+            - mountPath: /usr/loca/bin/etcd-snapshot-backup-disconnected.sh
+              name: etcd-backup-scripts
+              subPath: etcd-snapshot-backup-disconnected.sh
           nodeSelector:
             node-role.kubernetes.io/master: ""
           dnsPolicy: ClusterFirst
@@ -76,6 +80,12 @@ spec:
           - name: etcd-backup
             persistentVolumeClaim:
               claimName: {{ etcd_backup_pvc_claim }}
+          - name: etcd-backup-script
+            configMap:
+              name: "{{ etcd_backup_configmap }}"
+          - name: etcd-backup-scripts
+            configMap:
+              name: "{{ etcd_backup_configmap }}"
   schedule: '*/5 * * * *'
   startingDeadlineSeconds: 200
   successfulJobsHistoryLimit: 5


### PR DESCRIPTION
Here are the changes.
Added 2 x bash scripts

- etcd-backup.sh
- etcd-snapshot-backup-disconnected.sh

The cron job will invoke our customer backup script
/usr/local/bin/etcd-backup.sh

The custom backup script will first attempt to do a backup as per
the official documentation by invoking the below script
/usr/local/bin/etcd-snapshot-backup.sh

In a disconnectd the above script will fail since it cannot
downlaod the etcdctl command from the internet.
If the default backup script returns a non-zero exit code
we call the disconnected backup script
/usr/local/bin/etcd-snapshot-backup-disconnected.sh

The disconnected backup script is identical to the orignal script
The only changes are

- the ETCDCTL var now points to a local copy
- the function to download etcdctl was removed

See diff below
```
[root@helper bin]# diff etcd-snapshot-backup-disconnected.sh
etcd-snapshot-backup.sh
30c30,31
< ETCDCTL="/usr/bin/etcdctl"
---
> ETCD_VERSION=v3.3.10
> ETCDCTL="${ASSET_DIR}/bin/etcdctl"
39a41
>   dl_etcdctl
```