### PR TITLE
Adding role to configure ntp

### DIFF
--- a/roles/ocp-ntp/README.adoc
+++ b/roles/ocp-ntp/README.adoc
@@ -1,0 +1,38 @@
+== ocp-ntp
+This role is used to configure NTP for the RHCOS nodes by pushing out a chrony
+configuration to the nodes via the machineconfig operator. By default the role
+generates a macineconfig for 2 x machineconfig pools master and worker.
+
+=== Role Variables
+Default role variables that are defined.
+
+```
+ntp_servers: []
+
+ntp_pools: []
+
+```
+By default the role will noop if no ntp servers or ntp_pool servers are
+provided.
+
+
+
+=== Example Usage
+Example invocation of the role in a playbook
+
+[source,yaml]
+
+If you would like to configure cutom NTP servers to be used by the chrony
+daemon, you can invoke the role like this
+
+[source,yaml]
+----
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: ocp-ntp
+      vars:
+        ntp_servers:
+          - ntp1.example.com
+          - ntp2.example.com
+----

--- a/roles/ocp-ntp/apply/main.yml
+++ b/roles/ocp-ntp/apply/main.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: ocp-ntp
+

--- a/roles/ocp-ntp/defaults/main.yml
+++ b/roles/ocp-ntp/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# defaults file for ntp
+#
+machine_config_suffix: "chrony-config"
+
+machineconfigpools:
+  - master
+  - worker
+
+
+ntp_servers: []
+
+ntp_pools: []
+

--- a/roles/ocp-ntp/meta/main.yml
+++ b/roles/ocp-ntp/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.4
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/roles/ocp-ntp/tasks/configure-chrony.yml
+++ b/roles/ocp-ntp/tasks/configure-chrony.yml
@@ -1,0 +1,61 @@
+---
+# tasks file for ntp
+# Create machine configs to configure chrony in RHCOS
+
+- name: Get MachineConfigPool objects before pushing out new machineconfig
+  k8s_facts:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+  register: reg_mcpool_before
+
+- name: Create a new machine config to push out ntp config
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'machine-config.j2') }}"
+  loop: "{{ machineconfigpools }}"
+  loop_control:
+    loop_var: role
+  register: reg_mc_config
+
+- name: Wait for new machine configs to be rendered
+  k8s_facts:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+  register: reg_mcpool_after
+  vars:
+    mconfig_before: "{{ reg_mcpool_before.resources | map(attribute='spec.configuration.name') | list }}"
+    # this variable will holds the list of machine configs name before update
+    mconfig_after: "{{ reg_mcpool_after.resources | map(attribute='spec.configuration.name') | list }}"
+    # this variable will holds the list of machine configs after the update
+  until:
+    - mconfig_before | intersect(mconfig_after)  | length == 0
+    # if all the machine configs have been updated with the newly rendered
+    # machine config names, then the intersection of these 2 sets should be
+    # an empty set.
+  retries: 12 # wait for 2 minutes (12 retires x 10 sec = 120 sec)
+  delay: 10
+  tags:
+    - push_ntp_config
+  when:
+    - reg_mc_config.changed
+
+- name: Wait for updated machine configs to be pushed out
+  k8s_facts:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+  register: reg_mcpool_status
+  vars:
+    status_query: "resources[*].status.conditions[?type=='Updated'].status"
+    # query to extract all status for the UPDATED column in machine config pool
+    update_status: "{{ reg_mcpool_status | json_query(status_query) | flatten | unique }}"
+    # once have all the status in an array, flatten it and unique it.
+    # All of the status's should be True. So after flattening and uniquing it
+    # we are expecting to see an array with just 1 element ['True']
+  until:
+    - update_status == ['True']
+  retries: 60 # wait for 1 hour max
+  delay: 60
+  # TODO: As of now we wait for 1 hours for the config changes to be pushed out
+  # This is purely an arbitary number based on what we found whilst installing
+  # a fresh cluster. Ideally the amount of time we wait, should be a factor
+  # of the total number nodes in the cluster. May be a future nice have :-)

--- a/roles/ocp-ntp/tasks/main.yml
+++ b/roles/ocp-ntp/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# tasks file for ocp-ntp
+
+# Only invoke the configure-chrony.yml tasks if either of the variables
+# contain a list of NTP servers / pool names
+- include_tasks: configure-chrony.yml
+  when:
+    - ntp_servers or ntp_pools
+

--- a/roles/ocp-ntp/templates/chrony.conf.j2
+++ b/roles/ocp-ntp/templates/chrony.conf.j2
@@ -1,0 +1,10 @@
+{% for i in ntp_servers %}
+server {{ i }} iburst
+{% endfor %}
+{% for i in ntp_pools %}
+pool {{ i }} iburst
+{% endfor %}
+driftfile /var/lib/chrony/drift
+makestep 1.0 3
+rtcsync
+logdir /var/log/chrony

--- a/roles/ocp-ntp/templates/machine-config.j2
+++ b/roles/ocp-ntp/templates/machine-config.j2
@@ -1,0 +1,18 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: {{ role }}
+  name: {{ role }}-{{ machine_config_suffix}}
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ lookup('template', 'chrony.conf.j2') | b64encode }}
+        filesystem: root
+        mode: 420
+        path: /etc/chrony.conf
+    osImageURL: ""


### PR DESCRIPTION
Important: you will need to provide a list of ntp servers, or ntp pool
servers when including the ocp-ntp role. Otherwise the role will just
noop.