### PR TITLE
Moar Refactoring

### DIFF
--- a/roles/vsphere-csi-driver/README.adoc
+++ b/roles/vsphere-csi-driver/README.adoc
@@ -32,4 +32,4 @@ Primary usecase where this was developed and tested for.
 TODO:
 
   - Documentation is a work in progress :-)
-  - Test / Validate the role works well when zoning is enabled
+  - Test / Validate the role works well when zoning is disabled

--- a/roles/vsphere-csi-driver/defaults/main.yml
+++ b/roles/vsphere-csi-driver/defaults/main.yml
@@ -4,14 +4,21 @@
 vsphere_namespace: vsphere
 vsphere_username: "<username>"
 vsphere_password: "<password>"
+vsphere_secret_name: "vsphere-creds"
 vsphere_cluster_id: "cluster01"
+
+vsphere_container_images:
+  cpi:
+    manager: "latest"
+  csi:
+    driver: "v1.0.2"
+    syncer: "v1.0.2"
 
 # The settings defined in global conf will be inheritted by all vcenters unless
 # ofcourse you override it.
 vsphere_global_conf:
   port: "443"
   insecure-flag: "true"
-  secret-name: "vsphere-creds"
 
 vsphere_vcenters:
   - name: vcenter1.example.com # must be a reachable FQDN / use IP address

--- a/roles/vsphere-csi-driver/defaults/main.yml
+++ b/roles/vsphere-csi-driver/defaults/main.yml
@@ -7,12 +7,21 @@ vsphere_password: "<password>"
 vsphere_secret_name: "vsphere-creds"
 vsphere_cluster_id: "cluster01"
 
+
+# List of all the images used by the vsphere cpi/csi storage driver.
+# Moved it out of the teamplte to be able to upgrade them easily
+# NOTE: The onus is on the end user to make sure the yaml files does not
+# change over time. I would recommend period diffs with the upstream version
 vsphere_container_images:
   cpi:
-    manager: "latest"
+    manager: "gcr.io/cloud-provider-vsphere/cpi/release/manager:latest"
   csi:
-    driver: "v1.0.2"
-    syncer: "v1.0.2"
+    driver: "gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2"
+    syncer: "gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.2"
+    csi_attacher: "quay.io/k8scsi/csi-attacher:v1.1.1"
+    livenessprobe: "quay.io/k8scsi/livenessprobe:v1.1.0"
+    csi_provisioner: "quay.io/k8scsi/csi-provisioner:v1.2.2"
+    csi_node_driver_registrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
 
 # The settings defined in global conf will be inheritted by all vcenters unless
 # ofcourse you override it.

--- a/roles/vsphere-csi-driver/defaults/main.yml
+++ b/roles/vsphere-csi-driver/defaults/main.yml
@@ -23,6 +23,13 @@ vsphere_container_images:
     csi_provisioner: "quay.io/k8scsi/csi-provisioner:v1.2.2"
     csi_node_driver_registrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
 
+# Controls the frequency at which CSI syncer container will syncronise the vms
+# from vSphere to the cluster. When a new node is added to the cluster the CSI
+# has to sync the new VM's details bteween the vsphere and the OCP cluster.
+# Only after this can pods with storage be sheduled to the new node.
+# The default setting is 30 minutes. (as provided by vmware)
+full_sync_interval_minutes: 30
+
 # The settings defined in global conf will be inheritted by all vcenters unless
 # ofcourse you override it.
 vsphere_global_conf:

--- a/roles/vsphere-csi-driver/tasks/setup-cpi.yml
+++ b/roles/vsphere-csi-driver/tasks/setup-cpi.yml
@@ -38,21 +38,27 @@
   when:
     - not ( node_taints is contains("node.cloudprovider.kubernetes.io/uninitialized") )
     - not ( provider_id )
-- name: Create cloud-controller-manager roles
-  command: oc apply -f {{ role_path }}/files/cpi/cloud-controller-manager-roles.yaml
-  register: vsphere_ccm_roles
-  changed_when: vsphere_ccm_roles.stdout.find(" unchanged") == -1
 
 - name: Ensure tmpdir exists for vsphere cpi
   file:
     path: "{{ vsphere_cpi_tmpdir }}"
     state: directory
 
+- name: Generate cloud-controller-manager-roles yaml
+  template:
+    src: cpi/cloud-controller-manager-roles.yaml.j2
+    dest: "{{ vsphere_cpi_tmpdir }}/cloud-controller-manager-roles.yaml"
+
+- name: Apply cloud-controller-manager-roles yaml
+  command: oc apply -f {{ vsphere_cpi_tmpdir }}/cloud-controller-manager-roles.yaml
+  register: vsphere_ccm_roles
+  changed_when: vsphere_ccm_roles.stdout.find(" unchanged") == -1
+
 - name: Generate controller-manager role bindings yaml
   template:
     src: cpi/cloud-controller-manager-role-bindings.yaml.j2
     dest: "{{ vsphere_cpi_tmpdir }}/cloud-controller-manager-role-bindings.yaml"
-  
+
 - name: Apply controller-manager role bindings yaml
   command: oc apply -f {{ vsphere_cpi_tmpdir }}/cloud-controller-manager-role-bindings.yaml
   register: vsphere_ccm_role_bindings
@@ -65,8 +71,8 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'cpi/vsphere-cpi-kube-system_rolebinding.yaml.j2') }}"
-# Equivalent to running the below command. Moved it to use the k8s module ot make it 
-# idempotent.
+# Equivalent to running the below command. Moved it to use the k8s module ot
+# make it idempotent.
 #    oc create rolebinding -n kube-system vsphere-cpi-kubesystem \
 #    --role=extension-apiserver-authentication-reader \
 #    --serviceaccount={{ vsphere_namespace }}:cloud-controller-manager

--- a/roles/vsphere-csi-driver/tasks/setup-cpi.yml
+++ b/roles/vsphere-csi-driver/tasks/setup-cpi.yml
@@ -33,14 +33,11 @@
     ocp_nodes: "{{ reg_nodes | json_query('resources[*].metadata.name') }}"
     taint_query: "resources[?metadata.name=='{{ ocp_node }}'].spec.taints[].key"
     node_taints: "{{ reg_nodes | json_query(taint_query) }}"
-    label_query: "resources[?metadata.name=='{{ ocp_node }}'].metadata.labels"
-    node_labels: "{{ (reg_nodes | json_query(label_query))[0].keys() | list }}"
+    provider_query: "resources[?metadata.name=='{{ ocp_node }}'].spec.providerID"
+    provider_id: "{{ (reg_nodes | json_query(provider_query)) }}"
   when:
     - not ( node_taints is contains("node.cloudprovider.kubernetes.io/uninitialized") )
-    - not ( node_labels is contains("failure-domain.beta.kubernetes.io/region") or
-            node_labels is contains("failure-domain.beta.kubernetes.io/zone")
-          )
-
+    - not ( provider_id )
 - name: Create cloud-controller-manager roles
   command: oc apply -f {{ role_path }}/files/cpi/cloud-controller-manager-roles.yaml
   register: vsphere_ccm_roles

--- a/roles/vsphere-csi-driver/templates/cpi/cloud-controller-manager-role-bindings.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/cpi/cloud-controller-manager-role-bindings.yaml.j2
@@ -1,3 +1,4 @@
+# Source: https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
 apiVersion: v1
 items:
 - apiVersion: rbac.authorization.k8s.io/v1

--- a/roles/vsphere-csi-driver/templates/cpi/cloud-controller-manager-roles.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/cpi/cloud-controller-manager-roles.yaml.j2
@@ -1,3 +1,4 @@
+# Source: https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/manifests/controller-manager/cloud-controller-manager-roles.yaml
 apiVersion: v1
 items:
 - apiVersion: rbac.authorization.k8s.io/v1

--- a/roles/vsphere-csi-driver/templates/cpi/cpi-vsphere.conf.j2
+++ b/roles/vsphere-csi-driver/templates/cpi/cpi-vsphere.conf.j2
@@ -1,12 +1,9 @@
 [Global]
 {% for key, value in vsphere_global_conf.items() %}
-{% if key == 'secret-name' %}
-{{ key }} = cpi-{{ value }}
-{% else %}
 {{ key }} = {{ value }}
-{% endif %}
 {% endfor %}
 secret-namespace = {{ vsphere_namespace }}
+secret-name = cpi-{{ vsphere_secret_name }}
 
 
 {% for vcenter in vsphere_vcenters %}

--- a/roles/vsphere-csi-driver/templates/cpi/vsphere-cloud-controller-manager-ds.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/cpi/vsphere-cloud-controller-manager-ds.yaml.j2
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: vsphere-cloud-controller-manager
-          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:latest
+          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:{{ vsphere_container_images.cpi.manager }}
           args:
             - --v=2
             - --cloud-provider=vsphere

--- a/roles/vsphere-csi-driver/templates/cpi/vsphere-cloud-controller-manager-ds.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/cpi/vsphere-cloud-controller-manager-ds.yaml.j2
@@ -1,3 +1,4 @@
+# Source: https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -36,7 +37,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: vsphere-cloud-controller-manager
-          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:{{ vsphere_container_images.cpi.manager }}
+          image: {{ vsphere_container_images.cpi.manager }}
           args:
             - --v=2
             - --cloud-provider=vsphere

--- a/roles/vsphere-csi-driver/templates/csi/csi-secret.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/csi/csi-secret.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-{{ vsphere_global_conf["secret-name"] }}
+  name: csi-{{ vsphere_secret_name }}
   namespace: {{ vsphere_namespace }}
 type: Opaque
 data:

--- a/roles/vsphere-csi-driver/templates/csi/csi-vsphere.conf.j2
+++ b/roles/vsphere-csi-driver/templates/csi/csi-vsphere.conf.j2
@@ -1,9 +1,7 @@
 [Global]
 cluster-id = "{{ vsphere_cluster_id }}"
 {% for key, value in vsphere_global_conf.items() %}
-{% if key not in ['secret-name'] %}
 {{ key }} = {{ value }}
-{% endif %}
 {% endfor %}
 
 {% for vcenter in vsphere_vcenters %}

--- a/roles/vsphere-csi-driver/templates/csi/vsphere-csi-controller-ss.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/csi/vsphere-csi-controller-ss.yaml.j2
@@ -40,7 +40,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:{{ vsphere_container_images.csi.driver }}
           lifecycle:
             preStop:
               exec:
@@ -84,7 +84,7 @@ spec:
             - mountPath: /var/lib/kubelet/plugins_registry/
               name: socket-dir
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v1.0.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:{{ vsphere_container_images.csi.syncer }}
           args:
             - "--v=2"
           imagePullPolicy: "Always"

--- a/roles/vsphere-csi-driver/templates/csi/vsphere-csi-controller-ss.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/csi/vsphere-csi-controller-ss.yaml.j2
@@ -28,7 +28,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.1.1
+          image: {{ vsphere_container_images.csi.csi_attacher }}
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -40,7 +40,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:{{ vsphere_container_images.csi.driver }}
+          image: {{ vsphere_container_images.csi.driver }}
           lifecycle:
             preStop:
               exec:
@@ -74,7 +74,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: {{ vsphere_container_images.csi.livenessprobe }}
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -84,7 +84,7 @@ spec:
             - mountPath: /var/lib/kubelet/plugins_registry/
               name: socket-dir
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:{{ vsphere_container_images.csi.syncer }}
+          image: {{ vsphere_container_images.csi.syncer }}
           args:
             - "--v=2"
           imagePullPolicy: "Always"
@@ -98,7 +98,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.2.2
+          image: {{ vsphere_container_images.csi.csi_provisioner }}
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/roles/vsphere-csi-driver/templates/csi/vsphere-csi-controller-ss.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/csi/vsphere-csi-controller-ss.yaml.j2
@@ -90,7 +90,7 @@ spec:
           imagePullPolicy: "Always"
           env:
             - name: FULL_SYNC_INTERVAL_MINUTES
-              value: "30"
+              value: "{{ full_sync_interval_minutes }}"
             - name: VSPHERE_CSI_CONFIG
               value: "/etc/cloud/csi-vsphere.conf"
           volumeMounts:

--- a/roles/vsphere-csi-driver/templates/csi/vsphere-csi-node-ds.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/csi/vsphere-csi-node-ds.yaml.j2
@@ -41,7 +41,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v1.0.2
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:{{ vsphere_container_images.csi.driver }}
           imagePullPolicy: "Always"
           env:
             - name: NODE_NAME

--- a/roles/vsphere-csi-driver/templates/csi/vsphere-csi-node-ds.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/csi/vsphere-csi-node-ds.yaml.j2
@@ -1,3 +1,4 @@
+# Source: https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/master/manifests/1.14/deploy/vsphere-csi-node-ds.yaml
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -19,7 +20,7 @@ spec:
       serviceAccountName: vsphere-csi-controller
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: {{ vsphere_container_images.csi.csi_node_driver_registrar }}
           lifecycle:
             preStop:
               exec:
@@ -41,7 +42,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:{{ vsphere_container_images.csi.driver }}
+          image: {{ vsphere_container_images.csi.driver }}
           imagePullPolicy: "Always"
           env:
             - name: NODE_NAME
@@ -95,7 +96,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: {{ vsphere_container_images.csi.livenessprobe }}
           args:
             - "--csi-address=$(ADDRESS)"
           env:


### PR DESCRIPTION
Several Changes in thie PR.
- Moved all image resferences to varibles in the defaults/main.yml file
-- This should allow for easier upgrades in future when the image tags get bumped.
- Changed the condion use to check/decide if a node needs to be tained as unconfigured
-- A node is tained as unconfigured if it doesn't have a provider id in it's spec
-- This is comes in handy when new ndoes are added to the cluster as part of organic growth
- Added variable to control the frequency at which the syncer container syncs
- Moved a bunch of variables around to make it easier to template