### PR TITLE
Added additional check to wait for cluste operaotor api

### DIFF
--- a/wait-for-bootstrap.yml
+++ b/wait-for-bootstrap.yml
@@ -26,6 +26,17 @@
         dest: /tmp/cluster_operators.json
       when: save_json | bool
 
+    - name: Wait for cluster operator api call to be successfull
+      k8s_facts:
+        api_version: config.openshift.io/v1
+        kind: ClusterOperator
+      register: reg_ocp_co
+      ignore_errors: true
+      until:
+        - reg_ocp_co.rc == 0
+      retries: 60 # wait for 1 hour max
+      delay: 60
+
 ###############################################################################
 # I tend to use jmespath_terminal to look at the json output and filter my
 # queries so that I have a working working query when I start using it in


### PR DESCRIPTION
In my initial testing, `oc get co` was already returning a few
operators. this meant that my json queries would always work. It was
only when I started testing with a cluster install which didn't even
have a working api running, I noticed that the json query vars were
failing. So added an additinal check to wait for `oc get co` to return a
valid resonpse before we start polling the cluster operators.