### PR TITLE
Adding tolerations for the CSI-Node DaemonSet

### DIFF
--- a/roles/vsphere-csi-driver/templates/csi/vsphere-csi-node-ds.yaml.j2
+++ b/roles/vsphere-csi-driver/templates/csi/vsphere-csi-node-ds.yaml.j2
@@ -16,6 +16,9 @@ spec:
         app: vsphere-csi-node
         role: vsphere-csi
     spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
       dnsPolicy: "Default"
       serviceAccountName: vsphere-csi-controller
       containers:


### PR DESCRIPTION
Noticed that the CSINode objects are not created for the master nodes.
As a result, it is not posisble to schedule Pods on the master node that
make use of the volumes created by the vsphere-csi driver.
Created an issue upstream for the same, will see what the feedback is.
https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/140

Adding this patch willmake sure the csi-node DaemonSet runs on the
master nodes and registers the master nodes as CSINodes.