### PR TITLE
Adding role to configure ImageRegistry Operator

### DIFF
--- a/roles/image-registry/README.adoc
+++ b/roles/image-registry/README.adoc
@@ -1,0 +1,53 @@
+== image-registry
+This role configures the image-registry on freshly installed OpenShift cluster.
+
+The following steps are taken by the role
+
+- Change the managementState to Managed for the registryoperator config
+- Configure storage for the ImageRegistry
+
+=== Role Variables
+Default role variables that are defined.
+```
+image_registry_size: 100Gi
+image_regitry_emptydir: false
+```
+
+=== Example Usage
+Example invocation of the role in a playbook
+
+[source,yaml]
+----
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: image-registry
+----
+
+OR if you want to override some default variables
+
+[source,yaml]
+----
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: image-registry
+      vars:
+        image_regitry_emptydir: true
+----
+
+If you would like to use the role without including it or writing a playbook,
+from the root of this github repo you can run the following.
+
+[source,bash]
+----
+ansible-playbook roles/image-registry/apply/main.yml \
+                 -e image_regitry_emptydir=true
+----
+
+TODO:
+
+- Been meaning to use image_registry_size to be able to specify the size of the
+  storage volume that is claimed. The image-registry by default will claim a
+  volume of size 100Gi
+- Mande a bunch of changes and haven't tested it. Adding this as a reminder

--- a/roles/image-registry/apply/main.yml
+++ b/roles/image-registry/apply/main.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: image-registry
+

--- a/roles/image-registry/defaults/main.yaml
+++ b/roles/image-registry/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+image_registry_size: 100Gi
+image_regitry_emptydir: false

--- a/roles/image-registry/meta/main.yml
+++ b/roles/image-registry/meta/main.yml
@@ -1,0 +1,55 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.4
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies:
+  - role: ocp-env
+  - role: sanity-check
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/roles/image-registry/tasks/main.yaml
+++ b/roles/image-registry/tasks/main.yaml
@@ -1,0 +1,56 @@
+---
+# Prepare Image Registry
+
+- name: get config for imageregistry
+  k8s_facts:
+    api_version: imageregistry.operator.openshift.io/v1
+    kind: Config
+    name: cluster
+  register: reg_imagecfg
+
+# Configure PVC storage provided the variable image_registry_emptydir variable
+# is false.
+- name: Configure PVC storage for Image Registry
+  block:
+    - name: Remove emptyDir storage if configured
+      shell: >-
+        oc patch configs.imageregistry.operator.openshift.io/cluster
+        --type json
+        --patch='[{"op":"remove","path":"/spec/storage/emptyDir"}]'
+      when:
+        - reg_imagecfg['resources'][0]['spec']['storage']['emptyDir'] is defined
+
+    - name: Assign pvc to image registry if it is not already assigned
+      shell: >-
+        oc patch configs.imageregistry.operator.openshift.io/cluster
+        --type merge
+        --patch='{"spec":{"storage":{"pvc":{"claim":""}}}}'
+      when:
+        - reg_imagecfg['resources'][0]['spec']['storage']['pvc'] is not defined
+  when:
+    - not image_regitry_emptydir | bool
+
+###############################################################################
+# NOTE: This task will setup emptyDir storage for image-registry
+###############################################################################
+- name: Configure emptyDir storage for Image Registry
+  shell: >-
+    oc patch configs.imageregistry.operator.openshift.io/cluster
+    --type merge
+    --patch='{"spec":{"storage":{"emptyDir":{}}}}'
+  when:
+    - image_regitry_emptydir | bool
+    - reg_imagecfg['resources'][0]['spec']['storage']['emptyDir'] is defined
+###############################################################################
+
+###############################################################################
+# NOTE: This attribute was introduced in OCP 4.3
+###############################################################################
+- name: Change image registry ManagementState
+  shell: >-
+    oc patch configs.imageregistry.operator.openshift.io/cluster
+    --type merge
+    --patch='{"spec":{"managementState":"Managed"}}}'
+  when:
+    - reg_imagecfg['resources'][0]['spec']['managementState'] == "Removed"
+###############################################################################


### PR DESCRIPTION
A newly installed cluster has an ImageRegistry operator in Removed status (starting OCP 4.3)

We make sure the Operator is marked as Managed
as well as allocate storage for ImageRegistry

The role will either configure emptyDir or configure a pvc claim.