### PR TITLE
Adding role to configure TLS certs for the default ingress controller

### DIFF
--- a/ingress-tls-cert/README.adoc
+++ b/ingress-tls-cert/README.adoc
@@ -1,0 +1,8 @@
+== ingres-tls-cert
+
+This role will save the TLS cert as a Secret in OpenShift and reconfigures the
+default ingress controller to use this secret for it's defaultCertificate.
+
+=== TODO
+
+- Need to update the readme

--- a/ingress-tls-cert/apply/main.yml
+++ b/ingress-tls-cert/apply/main.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  tasks:
+    - include_role:
+        nome: ingress-tls-cert

--- a/ingress-tls-cert/defaults/main.yml
+++ b/ingress-tls-cert/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# defaults file for ingress-tls-cert
+
+ocp_cluster_id: "demo"
+
+# This variable should contain the certification for the apps sub domain.
+# the variable should include the full cert chain. including intermediate
+# and root ca cert.
+ingress_certs: ""
+ingress_key: ""
+
+
+##############
+# If you have the cert and key in a file stored in pem format you can use the lookup plugin
+# and load the file into the variable
+# NOTE: When using the lookup plugin the contents of the file are loaded as is.
+#       The secret stored in OCP expects the new line char at the end for tls.crt and tls.key
+#
+# IDEALLY: you want a lookup plugin which will look up the necessary cert and key from a vault
+#          like hashicorp vault
+#
+# ingress_certs: "{{ lookup('file', '{{ inventory_dir }}/config/{{ ocp_cluster_id }}/apps-domain.pem') }}\n"
+# ingress_key: "{{ lookup('file', '{{ inventory_dir }}/config/{{ ocp_cluster_id }}/apps-domain.key') }}\n"

--- a/ingress-tls-cert/meta/main.yml
+++ b/ingress-tls-cert/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/ingress-tls-cert/tasks/main.yml
+++ b/ingress-tls-cert/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# tasks file for ingress-tls-cert
+
+- name: Create secret for holding ingress ssl cert
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: kubernetes.io/tls
+      metadata:
+        name: "{{ ocp_cluster_id }}-cert"
+        namespace: openshift-ingress
+      data:
+        tls.crt: "{{ ingress_certs | b64encode }}"
+        tls.key: "{{ ingress_key | b64encode }}"
+
+- name: Patch the default ingress router
+  k8s:
+    state: present
+    definition:
+      apiVersion: operator.openshift.io/v1
+      kind: IngressController
+      metadata:
+        name: default
+        namespace: openshift-ingress-operator
+      spec:
+        defaultCertificate:
+          name: "{{ ocp_cluster_id }}-cert"
+        replicas: 3


### PR DESCRIPTION
The role expects 2 x variable that are expected to hold the private key
and the TLC cert to be used. How you get the cert and key to these
variables is up tto you. ansile vault, hashicorop vault or a simple file
lookup.